### PR TITLE
Remove WeakRefStrings from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,6 +5,5 @@ JSON 0.8.0
 CSV 0.2.1
 AutoHashEquals 0.1.1
 Geodesy 0.3.0
-WeakRefStrings  0.1.0
 HDF5 0.8.5
 Missings 0.2.5


### PR DESCRIPTION
It doesn't seem to be loaded/used anywhere in the package