### PR TITLE
Fix PyCall build in CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 script:
   - export PYTHON=""  # Configure PyCall to use the Conda.jl package's Python
   - OPTIONS=$(julia -e 'VERSION == v"0.6.0" && print("--inline=no")')  # https://github.com/JuliaLang/julia/issues/22582
-  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); Pkg.checkout("PyCall"); Pkg.test("SyntheticGrids"; coverage=true)'
+  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); Pkg.test("SyntheticGrids"; coverage=true)'
 after_success:
   # build documentation
   - julia -e 'Pkg.add("Documenter")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 script:
   - export PYTHON=""  # Configure PyCall to use the Conda.jl package's Python
   - OPTIONS=$(julia -e 'VERSION == v"0.6.0" && print("--inline=no")')  # https://github.com/JuliaLang/julia/issues/22582
-  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); Pkg.test("SyntheticGrids"; coverage=true)'
+  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); ENV["PYTHON"] = ""; Pkg.build("PyCall"); Pkg.test("SyntheticGrids"; coverage=true)'
 after_success:
   # build documentation
   - julia -e 'Pkg.add("Documenter")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 script:
   - export PYTHON=""  # Configure PyCall to use the Conda.jl package's Python
   - OPTIONS=$(julia -e 'VERSION == v"0.6.0" && print("--inline=no")')  # https://github.com/JuliaLang/julia/issues/22582
-  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); ENV["PYTHON"] = ""; Pkg.build("PyCall"); Pkg.test("SyntheticGrids"; coverage=true)'
+  - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("SyntheticGrids"); Pkg.build("PyCall"); Pkg.test("SyntheticGrids"; coverage=true)'
 after_success:
   # build documentation
   - julia -e 'Pkg.add("Documenter")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6.1
 Conda 0.5.3
-PyCall 1.10.0
+PyCall 1.10.0 1.18.6
 JSON 0.8.0
 CSV 0.2.1
 AutoHashEquals 0.1.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6.1
 Conda 0.5.3
-PyCall 1.10.0 1.18.6
+PyCall 1.10.0
 JSON 0.8.0
 CSV 0.2.1
 AutoHashEquals 0.1.1


### PR DESCRIPTION
Changes (likely in PyCall) have made it such that the old master does not pass CI anymore if reran. This should take care of that by upper bounding PyCall and building it properly in Travis.